### PR TITLE
fix: Allow Stylelint 9 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/technology-ebay-de/stylelint-config-motor-talk#readme",
   "peerDependencies": {
-    "stylelint": ">= 8.0.0 < 9.0.0"
+    "stylelint": ">= 8.0.0 < 10.0.0"
   }
 }


### PR DESCRIPTION
I think you have to publish the change as well.