### PR TITLE
PLY-473: Set "number-leading-zero" to "always"

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ module.exports = {
     "no-extra-semicolons": true,
     "no-invalid-double-slash-comments": true,
     "no-missing-end-of-source-newline": true,
-    "number-leading-zero": "never",
+    "number-leading-zero": "always",
     "number-no-trailing-zeros": true,
     "property-case": "lower",
     "property-no-unknown": true,


### PR DESCRIPTION
Adjust our config so we always use number-leading-zeros in our CSS files.

Further reading: https://stylelint.io/user-guide/rules/number-leading-zero/